### PR TITLE
Update test routines and documentation

### DIFF
--- a/documentation/documentation.html
+++ b/documentation/documentation.html
@@ -100,9 +100,6 @@
 <blockquote>
 <p>Files are opened with a time-out parameter. If an attempt is made to access a non-existent file, there is a delay of a few seconds before the error is signaled.</p>
 </blockquote>
-
-<p>FTG^%ZISH doesn&#8217;t work on GT.M because of the %ZISH call is non-supported. Instead, the programmer must load the file into a global first and send that global into the parser.</p>
-
 <p>Files are accessed in text mode. The result is that certain imbedded control characters are stripped from the input stream and never detected by the parser. Because these control characters are disallowed by XML, the parser will not report such documents as non-conforming.</p>
 
 <blockquote>

--- a/documentation/unit-tests.md
+++ b/documentation/unit-tests.md
@@ -7,3 +7,20 @@ The unit tests to run are the following:
  - D TEST^MXMLPATT
  - D TEST^MXMLTMPT
  - D ^MXMLDOMT
+
+Pre-installation known failures:
+
+The tests are written to test both existing functionality and the new
+functionality which is introduced with this patch.  If run on a system prior to
+this patch being installed, it is expected that two tests will fail within the
+MXMLDOMT routine.  The relevant part of the test output has been copied below:
+
+  XMLFILE - - Parse an XML document loacated on the File system (Sam's bug)
+  XMLFILE^MXMLDOMT - - Parse an XML document loacated on the File system (Sam's bu
+  g) - XML not parsed
+
+  XMLFILE^MXMLDOMT - - Parse an XML document loacated on the File system (Sam's bu
+  g) - XML not parsed
+  -----------------------------------------------------------------------  [FAIL]
+
+After the patch is installed, these failures should not be present.

--- a/routines/MXMLBLD.m
+++ b/routines/MXMLBLD.m
@@ -1,4 +1,4 @@
-MXMLBLD ; RWF/RWF - Recursive XML Writer ;2015-05-25  11:34 AM
+MXMLBLD ; RWF/RWF-OSEHRA/JPS - Recursive XML Writer ;2015-06-11  04:00 PM
  ;;2.3;XML PROCESSING UTILITIES;;May 25, 2015;Build 11
  QUIT
  ;
@@ -201,7 +201,7 @@ PUT(RETURN,STRING) ; PEP Proc/$$ - Put an XML Line into the RETURN Array
  S RETURN(CNT)=STRING
  QUIT:$QUIT CNT QUIT
  ;
-TEST D:$L($T(EN^%ut)) EN^%ut($T(+0),1) QUIT
+TEST D:$L($T(EN^%ut))&$L($T(^MXMLTMP1)) EN^%ut($T(+0),1) QUIT
  ;
 TESTPUT ; @TEST - Test PUT
  N RTN

--- a/routines/MXMLPATT.m
+++ b/routines/MXMLPATT.m
@@ -1,11 +1,11 @@
-MXMLPATT ; VEN/SMH - MXML XPath Processor Unit Tests;2015-05-25  11:38 AM
+MXMLPATT ; VEN/SMH-OSEHRA/JPS - MXML XPath Processor Unit Tests;2015-06-11  04:00 PM
  ;;2.3;XML PROCESSING UTILITIES;;May 25, 2015;Build 11
  ; (c) Sam Habiel 2014
 TEST ; M-Unit Entry point for Unit Testing
  SET IO=$PRINCIPAL
  NEW DIQUIET SET DIQUIET=1
  DO DT^DICRW
- DO:$LENGTH($TEXT(EN^%ut)) EN^%ut($TEXT(+0),1)
+ DO:$LENGTH($TEXT(EN^%ut))&$L($T(^MXMLPATH)) EN^%ut($TEXT(+0),1)
  QUIT
  ;
 STARTUP ; M-Unit start-up; Load XML Document

--- a/routines/MXMLTMPT.m
+++ b/routines/MXMLTMPT.m
@@ -1,4 +1,4 @@
-MXMLTMPT   ; VEN/GPL/SMH - XML Templater TEST CASES ;2015-05-25  11:44 AM
+MXMLTMPT   ; VEN/GPL/SMH-OSEHRA/JPS - XML Templater TEST CASES ;2015-06-11  04:00 PM
  ;;2.3;XML PROCESSING UTILITIES;;May 25, 2015;Build 11
  ; (c) George Lilly 2010-2013
  ; (c) Sam Habiel 2014
@@ -7,7 +7,7 @@ TEST ; M-Unit Entry point for Unit Testing
  S IO=$PRINCIPAL
  N DIQUIET S DIQUIET=1
  D DT^DICRW
- D:$L($T(EN^%ut)) EN^%ut($T(+0),1)
+ D:$L($T(EN^%ut))&$L($T(^MXMLTMP1)) EN^%ut($T(+0),1)
  QUIT
  ;
 STARTUP ; M-Unit Start-up


### PR DESCRIPTION
Update the test routines with behaivor for pre-install running of the test
routines.  Check for the existance of the new routines prior to running
the test.

Add a bit to the unit-tests.md file about the known failures on a system
without the patch installed.

Remove comment regarding incorrect documentation about GT.M and this
software.